### PR TITLE
Richte automatische releases ein

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,16 @@ jobs:
       provider: pages
       github-token: $GITHUB_TOKEN
       skip-cleanup: true
-      local-dir: build/docs/javadoc
+      local-dir: "build/docs/javadoc"
+  - name: deploy release
+    stage: deploy
+    if: (branch = master) AND (tag IS present)
+    script: "./gradlew distributionArtifacts"
+    deploy:
+      provider: releases
+      api_key: $GITHUB_TOKEN
+      draft: true
+      skip_cleanup: true
+      file_glob: true
+      file:
+        - "build/dist/*"

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,21 @@ javadoc {
 
 task distributionJar(type: Copy) {
     from jar.outputs
-    into "$buildDir/distributions"
+    into "$buildDir/dist"
 
     rename {
-        "${project.name}.jar"
+        "malprogramm.jar"
     }
+}
+
+task javadocZip(type: Zip) {
+    archiveName = "malprogramm-${project.version}-javadoc.zip"
+    destinationDir = file("${buildDir}/dist")
+
+    from javadoc
+}
+
+task distributionArtifacts {
+    dependsOn distributionJar
+    dependsOn javadocZip
 }


### PR DESCRIPTION
Eine ausführbare .jar-Datei und die Javadocs als .zip-Archiv werden dann automatisch als release hochgeladen.