### PR TITLE
Vereinfache das Speichern

### DIFF
--- a/src/me/jartreg/drawingapplication/MainWindow.java
+++ b/src/me/jartreg/drawingapplication/MainWindow.java
@@ -366,12 +366,16 @@ public class MainWindow extends JFrame {
     }
 
     /**
-     * Zeigt den "Speichern unter"-Dialog an und speichert das Bild in dieser Datei
+     * Speichert das Bild und lässt den Benutzer, sollte noch keine Datei ausgewählt worden sein, eine Datei auswählen.
      *
+     * @param forceDialog erzwingt das Anzeigen eines Speichern-Dialogs
      * @return ob das Speichern erfolgreich war
      */
-    public boolean saveAs() {
-        selectFile(); // Datei auswählen lassen
+    public boolean save(boolean forceDialog) {
+        // Datei auswählen lassen wenn noch keine ausgewählt ist oder forceDialog true ist
+        if (forceDialog || getFile() == null) {
+            selectFile();
+        }
 
         var file = getFile();
         if (file != null) { // wenn ausgewählt
@@ -382,21 +386,21 @@ public class MainWindow extends JFrame {
     }
 
     /**
+     * Zeigt den "Speichern unter"-Dialog an und speichert das Bild in dieser Datei
+     *
+     * @return ob das Speichern erfolgreich war
+     */
+    public boolean saveAs() {
+        return save(true);
+    }
+
+    /**
      * Speichert das Bild und lässt den Benutzer, sollte noch keine Datei ausgewählt worden sein, eine Datei auswählen
      *
      * @return ob das Speichern erfolgreich war
      */
     public boolean save() {
-        if (getFile() == null) {
-            selectFile();
-        }
-
-        var file = getFile();
-        if (file != null) { // wenn ausgewählt
-            return save(file); // speichern
-        }
-
-        return false;
+        return save(false);
     }
 
     /**

--- a/src/me/jartreg/drawingapplication/MainWindow.java
+++ b/src/me/jartreg/drawingapplication/MainWindow.java
@@ -340,10 +340,9 @@ public class MainWindow extends JFrame {
      * @param file die Datei, in die das Bild gespeichert werden soll
      */
     public void setFile(File file) {
-        var oldValue = this.file;
         this.file = file;
 
-        updateTitle(); // Titel aktualiesieren
+        updateTitle(); // Titel aktualisieren
     }
 
     /**
@@ -372,13 +371,15 @@ public class MainWindow extends JFrame {
      * @return ob das Speichern erfolgreich war
      */
     public boolean save(boolean forceDialog) {
+        var file = getFile();
+
         // Datei auswählen lassen wenn noch keine ausgewählt ist oder forceDialog true ist
-        if (forceDialog || getFile() == null) {
-            selectFile();
+        if (forceDialog || file == null) {
+            file = FileUtilities.showSaveDialog(this);
         }
 
-        var file = getFile();
         if (file != null) { // wenn ausgewählt
+            setFile(file); // aktualisieren, falls eine andere ausgewählt wurde
             return save(file); // speichern
         }
 
@@ -408,12 +409,5 @@ public class MainWindow extends JFrame {
         }
 
         return success;
-    }
-
-    /**
-     * Lässt deb Benutzer eine Datei auswählen, in der das Bild gespeichert werden soll
-     */
-    private void selectFile() {
-        setFile(FileUtilities.showSaveDialog(this));
     }
 }

--- a/src/me/jartreg/drawingapplication/MainWindow.java
+++ b/src/me/jartreg/drawingapplication/MainWindow.java
@@ -250,7 +250,7 @@ public class MainWindow extends JFrame {
                 );
 
                 if (result == JOptionPane.YES_OPTION) { // Der Benutzer will speichern
-                    if (!save()) { // speichern
+                    if (!save(false)) { // speichern
                         return; // wenn das Bild nicht gespeichert werden konnte, wird nichts gemacht
                     }
                 } else if (result != JOptionPane.NO_OPTION) {
@@ -383,24 +383,6 @@ public class MainWindow extends JFrame {
         }
 
         return false;
-    }
-
-    /**
-     * Zeigt den "Speichern unter"-Dialog an und speichert das Bild in dieser Datei
-     *
-     * @return ob das Speichern erfolgreich war
-     */
-    public boolean saveAs() {
-        return save(true);
-    }
-
-    /**
-     * Speichert das Bild und lässt den Benutzer, sollte noch keine Datei ausgewählt worden sein, eine Datei auswählen
-     *
-     * @return ob das Speichern erfolgreich war
-     */
-    public boolean save() {
-        return save(false);
     }
 
     /**

--- a/src/me/jartreg/drawingapplication/actions/SaveAction.java
+++ b/src/me/jartreg/drawingapplication/actions/SaveAction.java
@@ -33,6 +33,6 @@ public class SaveAction extends FileAction {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        getWindow().save(); // speichern
+        getWindow().save(false); // speichern
     }
 }

--- a/src/me/jartreg/drawingapplication/actions/SaveAsAction.java
+++ b/src/me/jartreg/drawingapplication/actions/SaveAsAction.java
@@ -33,6 +33,6 @@ public class SaveAsAction extends FileAction {
      */
     @Override
     public void actionPerformed(ActionEvent e) {
-        getWindow().saveAs();
+        getWindow().save(true); // Dialog anzeigen und speichern
     }
 }


### PR DESCRIPTION
Indem die Methoden `save()` und `saveAs()` durch eine Methode ersetzt werden, kann das Speichern um einiges Übersichtlicher gemacht werden.

fixes #9 